### PR TITLE
Prevent multiple calls to part.getTable method

### DIFF
--- a/src/service/loader-partial.js
+++ b/src/service/loader-partial.js
@@ -14,7 +14,9 @@ angular.module('pascalprecht.translate')
 function $translatePartialLoader() {
 
   'use strict';
-
+  
+  var loadedParts = []; //-> holds the already loaded parts to make sure we wontload them again.
+  
   /**
    * @constructor
    * @name Part
@@ -298,10 +300,13 @@ function $translatePartialLoader() {
           prioritizedParts = getPrioritizedParts();
 
       angular.forEach(prioritizedParts, function(part) {
-        loaders.push(
-          part.getTable(options.key, $q, $http, options.$http, options.urlTemplate, errorHandler)
-        );
-        part.urlTemplate = options.urlTemplate;
+        if(!_.contains(loadedParts, part.name)){ //-> check if translation was loaded before, if not go ahead and load
+          loaders.push(
+            part.getTable(options.key, $q, $http, options.$http, options.urlTemplate, errorHandler)
+          );
+          loadedParts.push(part.name); //-> register the loaded part so it won't be loaded again
+          part.urlTemplate = options.urlTemplate;
+        }
       });
 
       return $q.all(loaders)


### PR DESCRIPTION
When ever we are loading a new part, the forEach loop iterates through all the parts in getPrioritizedParts method and parts that were already loaded are being pushed again into loaders array. that results in multiple unnecessary calls to part.getTable method.
